### PR TITLE
Add Spring Boot example backend

### DIFF
--- a/spring-boot-example/README.md
+++ b/spring-boot-example/README.md
@@ -1,0 +1,20 @@
+# Spring Boot Example Backend
+
+This folder contains a minimal Spring Boot application that serves as a starting point for migrating n8n functionality to Java.
+
+The application exposes a single `/api/health` endpoint that returns `ok` to verify the server is running.
+
+## Running the example
+
+1. Ensure you have Java 17+ and Maven installed.
+2. Navigate to this directory:
+   ```bash
+   cd spring-boot-example
+   ```
+3. Build and run the application:
+   ```bash
+   mvn spring-boot:run
+   ```
+4. Access the endpoint at `http://localhost:8080/api/health`.
+
+This example does **not** replicate the full n8n backend. It is intended as a starting point for a potential migration to Spring Boot.

--- a/spring-boot-example/pom.xml
+++ b/spring-boot-example/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>n8n-spring-boot</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-boot-example/src/main/java/com/example/n8n/DemoApplication.java
+++ b/spring-boot-example/src/main/java/com/example/n8n/DemoApplication.java
@@ -1,0 +1,12 @@
+package com.example.n8n;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+}

--- a/spring-boot-example/src/main/java/com/example/n8n/controller/WorkflowController.java
+++ b/spring-boot-example/src/main/java/com/example/n8n/controller/WorkflowController.java
@@ -1,0 +1,13 @@
+package com.example.n8n.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class WorkflowController {
+
+    @GetMapping("/api/health")
+    public String health() {
+        return "ok";
+    }
+}

--- a/spring-boot-example/src/main/resources/application.properties
+++ b/spring-boot-example/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=8080


### PR DESCRIPTION
## Summary
- provide a minimal Java Spring Boot project as a starting point for migration
- expose a simple `/api/health` endpoint
- document how to run the example

## Testing
- `mvn -v` *(fails: command not found)*